### PR TITLE
fix: Make edgex-ui-go work in secure k8s

### DIFF
--- a/templates/edgex-ui/edgex-ui-deployment.yaml
+++ b/templates/edgex-ui/edgex-ui-deployment.yaml
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-{{- if not .Values.edgex.security.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,6 +39,8 @@ spec:
           hostIP: {{.Values.edgex.hostPortExternalBind}}
         {{- end}}
         env:
+        - name: SERVICEOPTIONS_PROXYMODE
+          value: direct
         - name: EDGEX_SECURITY_SECRET_STORE
       {{- if .Values.edgex.security.enabled }}
           value: "true"
@@ -75,4 +76,3 @@ spec:
       securityContext:
         runAsUser: {{ .Values.edgex.security.runAsUser }}
         runAsGroup: {{ .Values.edgex.security.runAsGroup }}
-{{- end }}

--- a/templates/edgex-ui/edgex-ui-service.yaml
+++ b/templates/edgex-ui/edgex-ui-service.yaml
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-{{- if not .Values.edgex.security.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,4 +15,3 @@ spec:
   selector:
     org.edgexfoundry.service: {{.Values.edgex.app.ui}}
   type: {{.Values.expose.type.ui}}
-{{- end }}


### PR DESCRIPTION
This PR is dependent on
https://github.com/edgexfoundry/edgex-ui-go/pull/637

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


## Testing Instructions
Wait until https://github.com/edgexfoundry/edgex-ui-go/pull/637 is merged before testing.
Will need to override edgex-ui image source to point at nexus.
